### PR TITLE
Add simple frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
-# CAT_Psikoologi_Frontend
-test
+# CAT Psikologi Frontend
+
+This is a minimal frontend to interact with the [CAT Psikologi Backend](https://github.com/cicero78M/CAT_Psikologi_Backend).
+
+## Setup
+
+Install dependencies and run the development server:
+
+```bash
+npm install
+npm start
+```
+
+The app will serve static files from the `public` folder on port `8080` by default.
+
+Ensure the backend is running on `http://localhost:3000` or adjust the `API_URL` in `public/app.js`.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cat_psikologi_frontend",
+  "version": "1.0.0",
+  "description": "Simple frontend for CAT Psikologi Backend",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,97 @@
+const API_URL = 'http://localhost:3000/api';
+let token = localStorage.getItem('token');
+
+function showMain() {
+  document.getElementById('auth').classList.add('hidden');
+  document.getElementById('main').classList.remove('hidden');
+}
+
+function showAuth() {
+  document.getElementById('auth').classList.remove('hidden');
+  document.getElementById('main').classList.add('hidden');
+}
+
+function register() {
+  const email = document.getElementById('regEmail').value;
+  const password = document.getElementById('regPassword').value;
+  fetch(`${API_URL}/auth/register`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password })
+  }).then(r => r.json()).then(data => {
+    alert('Registered');
+  }).catch(err => alert('Error: ' + err.message));
+}
+
+function login() {
+  const email = document.getElementById('logEmail').value;
+  const password = document.getElementById('logPassword').value;
+  fetch(`${API_URL}/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password })
+  }).then(r => r.json()).then(data => {
+    if (data.token) {
+      token = data.token;
+      localStorage.setItem('token', token);
+      showMain();
+    } else {
+      alert('Login failed');
+    }
+  }).catch(err => alert('Error: ' + err.message));
+}
+
+function logout() {
+  localStorage.removeItem('token');
+  token = null;
+  showAuth();
+}
+
+function loadUsers() {
+  fetch(`${API_URL}/users`, {
+    headers: { 'Authorization': `Bearer ${token}` }
+  }).then(r => r.json()).then(data => {
+    const list = document.getElementById('userList');
+    list.innerHTML = '';
+    data.forEach(u => {
+      const li = document.createElement('li');
+      li.textContent = `ID: ${u.id || ''} Email: ${u.email || ''}`;
+      list.appendChild(li);
+    });
+  }).catch(err => alert('Error: ' + err.message));
+}
+
+function loadQuestions() {
+  fetch(`${API_URL}/questions`, {
+    headers: { 'Authorization': `Bearer ${token}` }
+  }).then(r => r.json()).then(data => {
+    const list = document.getElementById('questionList');
+    list.innerHTML = '';
+    data.forEach(q => {
+      const li = document.createElement('li');
+      li.textContent = `ID: ${q.id || ''} Text: ${q.text || ''}`;
+      list.appendChild(li);
+    });
+  }).catch(err => alert('Error: ' + err.message));
+}
+
+function createQuestion() {
+  const text = document.getElementById('questionText').value;
+  fetch(`${API_URL}/questions`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${token}`
+    },
+    body: JSON.stringify({ text })
+  }).then(r => r.json()).then(data => {
+    alert('Question created');
+    loadQuestions();
+  }).catch(err => alert('Error: ' + err.message));
+}
+
+if (token) {
+  showMain();
+} else {
+  showAuth();
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CAT Psikologi Frontend</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 20px; }
+    #auth, #main { margin-bottom: 20px; }
+    input, button { margin: 5px 0; }
+    .hidden { display: none; }
+  </style>
+</head>
+<body>
+  <h1>CAT Psikologi Frontend</h1>
+
+  <div id="auth">
+    <h2>Register</h2>
+    <input type="email" id="regEmail" placeholder="Email"><br>
+    <input type="password" id="regPassword" placeholder="Password"><br>
+    <button onclick="register()">Register</button>
+
+    <h2>Login</h2>
+    <input type="email" id="logEmail" placeholder="Email"><br>
+    <input type="password" id="logPassword" placeholder="Password"><br>
+    <button onclick="login()">Login</button>
+  </div>
+
+  <div id="main" class="hidden">
+    <button onclick="logout()">Logout</button>
+
+    <h2>Users</h2>
+    <button onclick="loadUsers()">Load Users</button>
+    <ul id="userList"></ul>
+
+    <h2>Questions</h2>
+    <button onclick="loadQuestions()">Load Questions</button>
+    <ul id="questionList"></ul>
+
+    <h3>Create Question</h3>
+    <textarea id="questionText" rows="3" cols="40" placeholder="Question text"></textarea><br>
+    <button onclick="createQuestion()">Create</button>
+  </div>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const path = require('path');
+const app = express();
+
+app.use(express.static(path.join(__dirname, 'public')));
+
+const PORT = process.env.PORT || 8080;
+app.listen(PORT, () => console.log(`Frontend running on port ${PORT}`));


### PR DESCRIPTION
## Summary
- create minimal HTML/JS frontend for CAT Psikologi Backend
- add simple express server to serve static files
- document setup and usage in README

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6854d5bee560832798d7c6708e33d75a