### PR TITLE
Implement user profile and role management UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CAT Psikologi Frontend
 
-This project provides a very small web interface for the [CAT Psikologi Backend](https://github.com/cicero78M/CAT_Psikologi_Backend). It allows basic authentication and includes simple screens for question management, adaptive tests and admin tools.
+This project provides a very small web interface for the [CAT Psikologi Backend](https://github.com/cicero78M/CAT_Psikologi_Backend). It allows basic authentication and includes simple screens for question management, adaptive tests, user profiles and admin tools.
 
 ## Setup
 
@@ -14,6 +14,8 @@ npm start
 The app will serve static files from the `public` folder on port `8080` by default.
 
 Ensure the backend is running on `http://localhost:3000` or adjust the `API_URL` in `public/app.js`.
+
+The profile page allows users to edit their name, institution, role and upload a photo. Administrators can manage user roles from the **Pengguna** section.
 
 ## Built-in Question Bank API
 

--- a/public/index.html
+++ b/public/index.html
@@ -37,12 +37,17 @@
       <button onclick="showSection('resultSection')">Hasil</button>
       <button onclick="showSection('classSection')">Kelas</button>
       <button onclick="showSection('dashboardSection')">Dashboard</button>
+      <button onclick="showSection('usersSection')">Pengguna</button>
     </nav>
 
     <section id="profileSection" class="hidden">
       <h2>Profil Pengguna</h2>
       <input type="text" id="profileName" placeholder="Nama"><br>
       <input type="text" id="profileInstitution" placeholder="Institusi"><br>
+      <select id="profileRole">
+        <option value="user">User</option>
+        <option value="admin">Admin</option>
+      </select><br>
       <input type="file" id="profilePhoto"><br>
       <button onclick="updateProfile()">Simpan Profil</button>
       <h3>Reset Password</h3>
@@ -103,6 +108,12 @@
       <button onclick="loadDashboard()">Segarkan</button>
       <div id="summary"></div>
       <div id="notifications"></div>
+    </section>
+
+    <section id="usersSection" class="hidden">
+      <h2>Manajemen Pengguna</h2>
+      <button onclick="loadUsers()">Muat Pengguna</button>
+      <ul id="userList"></ul>
     </section>
   </div>
 


### PR DESCRIPTION
## Summary
- add user role dropdown in profile section
- show user management section with ability to update roles
- auto-load profile data after login
- document profile/role features in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6854df0c5ab8832794f254f19b78fa90