### PR TITLE
Make API URL configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm start
 
 The app will serve static files from the `public` folder on port `8080` by default.
 
-Ensure the backend is running on `http://localhost:3000` or adjust the `API_URL` in `public/app.js`.
+Ensure the backend is running (default `http://localhost:3000`) or set the environment variable `API_URL` when starting the server to point the frontend at a different backend.
 
 The profile page allows users to edit their name, institution, role and upload a photo. Administrators can manage user roles from the **Pengguna** section.
 
@@ -30,5 +30,5 @@ Available operations:
 - `DELETE /api/questions/:id` – remove a question
 
 This allows populating a small bank of questions without running the separate backend.
-The app serves static files from the `public` folder on port `8080` by default. Ensure the backend is available on `http://localhost:3000` or update `API_URL` in `public/app.js`.
+The app serves static files from the `public` folder on port `8080` by default. To connect to another backend set the `API_URL` environment variable before running `npm start`.
 

--- a/public/admin_bank.html
+++ b/public/admin_bank.html
@@ -27,6 +27,7 @@
     <button onclick="exportQuestions()">Export</button>
   </section>
 
+  <script src="config.js"></script>
   <script src="app.js"></script>
 </body>
 </html>

--- a/public/app.js
+++ b/public/app.js
@@ -1,4 +1,4 @@
-const API_URL = 'http://localhost:3000/api';
+const API_URL = window.API_URL || 'http://localhost:3000/api';
 let token = localStorage.getItem('token');
 
 function showMain() {

--- a/public/index.html
+++ b/public/index.html
@@ -117,6 +117,7 @@
     </section>
   </div>
 
+  <script src="config.js"></script>
   <script src="app.js"></script>
 </body>
 </html>

--- a/server.js
+++ b/server.js
@@ -6,6 +6,13 @@ const app = express();
 app.use(express.json());
 app.use(express.static(path.join(__dirname, 'public')));
 
+const API_URL = process.env.API_URL || 'http://localhost:3000/api';
+
+app.get('/config.js', (req, res) => {
+  res.type('application/javascript');
+  res.send(`window.API_URL = '${API_URL}';`);
+});
+
 const DATA_FILE = path.join(__dirname, 'data', 'questions.json');
 
 function loadQuestions() {


### PR DESCRIPTION
## Summary
- allow configuring backend URL via API_URL env variable
- load new configuration script in HTML files
- document backend URL configuration in README

## Testing
- `npm test` *(fails: Missing script)*
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_6854eb5791948327bfae4d983a2df3c5