### PR TITLE
Enable env config and CORS for web access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+API_URL=http://localhost:3000/api
+PORT=8080
+DATA_FILE=./data/questions.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules/
+.env
 *.log
+data/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ This project provides a very small web interface for the [CAT Psikologi Backend]
 
 ## Setup
 
-Install dependencies and run the development server:
+This project requires **Node.js 18** or newer.
+
+Install dependencies and run the development server. Copy `.env.example` to `.env` and adjust the variables if needed:
 
 ```bash
 npm install

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,12 @@
       "name": "cat_psikologi_frontend",
       "version": "1.0.0",
       "dependencies": {
+        "cors": "^2.8.5",
+        "dotenv": "^16.4.1",
         "express": "^4.18.2"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/accepts": {
@@ -128,6 +133,19 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "license": "MIT"
     },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -154,6 +172,18 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {
@@ -519,6 +549,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,11 @@
     "start": "node server.js"
   },
   "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.1",
     "express": "^4.18.2"
+  },
+  "engines": {
+    "node": ">=18"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,9 +1,12 @@
+require('dotenv').config();
 const express = require('express');
 const path = require('path');
 const fs = require('fs');
+const cors = require('cors');
 const app = express();
 
 app.use(express.json());
+app.use(cors());
 app.use(express.static(path.join(__dirname, 'public')));
 
 const API_URL = process.env.API_URL || 'http://localhost:3000/api';
@@ -13,7 +16,7 @@ app.get('/config.js', (req, res) => {
   res.send(`window.API_URL = '${API_URL}';`);
 });
 
-const DATA_FILE = path.join(__dirname, 'data', 'questions.json');
+const DATA_FILE = process.env.DATA_FILE || path.join(__dirname, 'data', 'questions.json');
 
 function loadQuestions() {
   try {
@@ -69,6 +72,10 @@ app.delete('/api/questions/:id', (req, res) => {
   const removed = questions.splice(index, 1)[0];
   saveQuestions(questions);
   res.json(removed);
+});
+
+app.get('*', (req, res) => {
+  res.sendFile(path.join(__dirname, 'public', 'index.html'));
 });
 
 const PORT = process.env.PORT || 8080;


### PR DESCRIPTION
## Summary
- enable dotenv and cors in Express server
- serve frontend for unknown routes
- provide `.env.example` and document Node requirement
- declare Node engine and dependencies
- ignore env, logs and data in git

## Testing
- `npm start` (manual)
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6854ee750af8832786bd132402ffdd7b