### PR TITLE
Add .env.example and clarify README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,8 @@
-API_URL=http://203.175.127.254:3000/api
-PORT=3001
-DATA_FILE=./data/questions.json
+# Base URL for the backend API
+API_URL=http://localhost:3000/api
+
+# Port for the Express server
+PORT=8080
+
+# Location of the question bank JSON file
+DATA_FILE=data/questions.json

--- a/README.md
+++ b/README.md
@@ -6,7 +6,14 @@ This project provides a very small web interface for the [CAT Psikologi Backend]
 
 This project requires **Node.js 18** or newer.
 
-Install dependencies and run the development server. Copy `.env.example` to `.env` and adjust the variables if needed:
+Install dependencies and run the development server. Copy `.env.example` to `.env` and adjust the variables if needed. The example file defines
+the following environment variables:
+
+- `API_URL` – base URL of the backend API
+- `PORT` – port for the Express server
+- `DATA_FILE` – path to the questions JSON file
+
+Run the development server with:
 
 ```bash
 npm install


### PR DESCRIPTION
## Summary
- document environment variable defaults in `.env.example`
- mention expected variables in the setup section of `README.md`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68561e60d6008327973d42b76889dff0